### PR TITLE
会員登録機能の編集、画像アップ機能（パブリック）の追加

### DIFF
--- a/laravel-vue-app/app/Article.php
+++ b/laravel-vue-app/app/Article.php
@@ -9,6 +9,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class Article extends Model
 {
 
+    protected $primaryKey = 'article_id';
+
     // 作成されたarticleのUserを取得
     public function user(): BelongsTo
     {

--- a/laravel-vue-app/app/Http/Controllers/Auth/LoginController.php
+++ b/laravel-vue-app/app/Http/Controllers/Auth/LoginController.php
@@ -42,7 +42,7 @@ class LoginController extends Controller
         $this->middleware('guest')->except('logout');
     }
 
-    // ログアウト時のリダイレクト先をnote一覧ページに変更
+    // ログアウト時のリダイレクト先をnoteトップページに変更
     protected function loggedOut(Request $request)
     {
         $this->guard()->logout();
@@ -51,7 +51,7 @@ class LoginController extends Controller
 
         $request->session()->regenerateToken();
 
-        return $this->loggedOut($request) ?: redirect('/list');
+        return $this->loggedOut($request) ?: redirect('/');
     }
 
     public function redirectToProvider(string $provider)

--- a/laravel-vue-app/app/Http/Controllers/Auth/RegisterController.php
+++ b/laravel-vue-app/app/Http/Controllers/Auth/RegisterController.php
@@ -31,7 +31,7 @@ class RegisterController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = '/';
+    protected $redirectTo = '/list';
 
     /**
      * Create a new controller instance.
@@ -54,7 +54,7 @@ class RegisterController extends Controller
         return Validator::make($data, [
             'name' => ['required', 'string', 'min:3', 'max:16', 'unique:users'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
-            'password' => ['required', 'string', 'min:8', 'confirmed'],
+            'password' => ['required', 'string', 'min:8'],
         ]);
     }
 
@@ -92,7 +92,7 @@ class RegisterController extends Controller
     {
         // バリデーションの実施
         $request->vaidate([
-            'name' =>['required', 'string', 'min:3', 'max:16', 'unique:users'],
+            'name' => ['required', 'string', 'min:3', 'max:16', 'unique:users'],
             'token' => ['required', 'string'],
         ]);
 
@@ -112,6 +112,5 @@ class RegisterController extends Controller
         $this->guard()->login($user, true);
 
         return $this->registered($request, $user) ?: redirect($this->redirectPath());
-
     }
 }

--- a/laravel-vue-app/app/Image.php
+++ b/laravel-vue-app/app/Image.php
@@ -6,10 +6,13 @@ use Illuminate\Database\Eloquent\Model;
 
 class Image extends Model
 {
+
+    protected $primaryKey = 'image_id';
+
     /**
      * このimageが添付されているarticleを取得
      */
-    public function articles()
+    public function articles_image()
     {
         return $this->belongsTo('App\Article');
     }

--- a/laravel-vue-app/app/User.php
+++ b/laravel-vue-app/app/User.php
@@ -12,6 +12,8 @@ class User extends Authenticatable
 {
     use Notifiable;
 
+    protected $primaryKey = 'user_id';
+
     /**
      * The attributes that are mass assignable.
      *
@@ -42,5 +44,13 @@ class User extends Authenticatable
     public function sendPasswordResetNotification($token)
     {
         $this->notify(new PasswordResetNotification($token, new BareMail()));
+    }
+
+    /**
+     * このarticleを所有するuserを取得
+     */
+    public function article()
+    {
+        return $this->belongsTo('App\User');
     }
 }

--- a/laravel-vue-app/resources/views/articles/create.blade.php
+++ b/laravel-vue-app/resources/views/articles/create.blade.php
@@ -25,7 +25,7 @@
 
     {{-- 画像登録 --}}
     <p>
-        <input type="file" class="btn image" name="image" value="画像登録"/>
+        <input type="file" class="btn image" name="file_name" value="画像登録" multiple/>
     </p>
 
 

--- a/laravel-vue-app/resources/views/articles/edit.blade.php
+++ b/laravel-vue-app/resources/views/articles/edit.blade.php
@@ -23,7 +23,7 @@
 
             {{-- 画像登録 --}}
             <p>
-              <input type="file" class="btn image" name="image" value="画像登録"/>
+              <input type="file" class="btn image" name="file_name" value="画像登録" multiple/>
             </p>
         </form>
 


### PR DESCRIPTION
What
・画像投稿機能の追加（未確認）
・会員登録のパスワード確認機能の解除（一時的に）
・ログイン後のリダイレクト先をページ一覧に変更

Why
・そもそも記事をDBに保存できない不具合発生中のため画像投稿の確認できませんでした
現在全力で対応しています。少々お待ちください
・アプリの動作確認をするために一時的にパスワード確認をしないようになっています。（ユーザー登録できないため）