### PR TITLE
画像バリデーションエラーの解消

### DIFF
--- a/laravel-vue-app/app/Http/Requests/ArticleRequest.php
+++ b/laravel-vue-app/app/Http/Requests/ArticleRequest.php
@@ -27,7 +27,7 @@ class ArticleRequest extends FormRequest
         return [
             'note_title' => ['required', 'max:100'],
             'content' => ['required', 'max:1000'],
-            'file_name' => ['image', 'nullable'],
+            'file_name' => ['nullable', 'file', 'mimes:jpg,jpeg,png,gif'],
         ];
     }
 

--- a/laravel-vue-app/resources/views/articles/create.blade.php
+++ b/laravel-vue-app/resources/views/articles/create.blade.php
@@ -24,7 +24,7 @@
     {{-- 入力内容に不備がある場合のエラーの表示方法について要検討 --}}
     {{-- @include('error_card_list') --}}
 
-    <form method="POST" action="{{ route('articles.store') }}">
+    <form method="POST" action="{{ route('articles.store') }}" enctype="multipart/form-data">
 
     {{-- 新規作成、編集でもform部分は共有使用する --}}
     @include('articles.form')

--- a/laravel-vue-app/resources/views/articles/edit.blade.php
+++ b/laravel-vue-app/resources/views/articles/edit.blade.php
@@ -13,7 +13,7 @@
     {{-- 入力内容に不備がある場合のエラーの表示方法について要検討 --}}
     {{-- @include('error_card_list') --}}
 
-        <form method="POST" action="{{ route('articles.update', ['article' => $article]) }}">
+        <form method="POST" action="{{ route('articles.update', ['article' => $article]) }}" enctype="multipart/form-data">
         @method('PATCH')
         @include('articles.form')
         {{-- noteの更新 --}}

--- a/laravel-vue-app/resources/views/articles/form.blade.php
+++ b/laravel-vue-app/resources/views/articles/form.blade.php
@@ -10,8 +10,8 @@
     </p>
 
         {{-- 内容入力 --}}
-        <textarea name="content" required class="form-control" rows="16" placeholder="ノート内容"
-        value="{{$article->content ?? old('content') }}"></textarea>
+        <textarea name="content" required class="form-control" rows="16" placeholder="ノート内容">{{$article->content ?? old('content') }}
+        </textarea>
 
 
 </div>

--- a/laravel-vue-app/resources/views/articles/toppage.blade.php
+++ b/laravel-vue-app/resources/views/articles/toppage.blade.php
@@ -11,7 +11,7 @@
 
     {{-- note入力画面 --}}
 
-    <form method="POST" action="{{ route('articles.store') }}">
+    <form method="POST" action="{{ route('articles.store') }}" enctype="multipart/form-data">
 
         {{-- form.bladeの読み込み  --}}
         @include('articles.form')


### PR DESCRIPTION
What
・formタグに画像データを送信するためにenctypeを追記
・form.blade.phpの編集

Why
・画像データを送信出来ていなかったためバリデーションエラーが発生していたため
・ノートの編集画面に入った時に、本文が表示されていなかったため