### PR TITLE
ノートと画像のカスケード関係を結びました

### DIFF
--- a/laravel-vue-app/app/Http/Controllers/ArticleController.php
+++ b/laravel-vue-app/app/Http/Controllers/ArticleController.php
@@ -99,7 +99,7 @@ class ArticleController extends Controller
     // noteの編集画面の表示
     public function edit(Article $article)
     {
-        $images = Image::where('article_id', $article)->latest()->get();
+        $images = Image::where('article_id', $article->article_id)->latest()->get();
         return view('articles.edit', ['article' => $article], ['images' => $images]);
     }
 

--- a/laravel-vue-app/app/Http/Controllers/ArticleController.php
+++ b/laravel-vue-app/app/Http/Controllers/ArticleController.php
@@ -152,9 +152,12 @@ class ArticleController extends Controller
     }
 
     // noteの削除
-    // noteを削除したら同時に添付していた画像も削除されるようにカスケードの関係にする必要あり
+    // noteを削除したら同時に添付していた画像も削除されるように
     public function destroy(Article $article)
     {
+        // note削除と同時に添付されている画像もpublicストレージから削除する
+        $image = Image::where('article_id', $article->article_id)->get();
+        // Storage::delete($image->image_title);
         $article->delete();
         return redirect()->route('articles.index');
     }

--- a/laravel-vue-app/app/Http/Controllers/ArticleController.php
+++ b/laravel-vue-app/app/Http/Controllers/ArticleController.php
@@ -71,8 +71,8 @@ class ArticleController extends Controller
             $image->article_id = $article->article_id;
             $image->file_name = $request->image;
 
-            // ローカルストレージへ画像を保存する
-            $path = Storage::putFileAs('', $request->file('image'), $image->image_title);
+            // パブリックストレージへ画像を保存する
+            $path = Storage::putFileAs('public', $request->file('image'), $image->image_title);
 
             // データベースエラー時にファイル削除を行うためトランザクションを利用する
             DB::beginTransaction();
@@ -127,8 +127,8 @@ class ArticleController extends Controller
             $image->article_id = $article->article_id;
             $image->file_name = $request->image;
 
-            // ローカルストレージへ画像を保存する
-            $path = Storage::putFileAs('', $request->file('image'), $image->image_title);
+            // パブリックストレージへ画像を保存する
+            $path = Storage::putFileAs('public', $request->file('image'), $image->image_title);
 
             // データベースエラー時にファイル削除を行うためトランザクションを利用する
             DB::beginTransaction();

--- a/laravel-vue-app/database/migrations/2020_09_29_054345_change_images_table_add_cascade.php
+++ b/laravel-vue-app/database/migrations/2020_09_29_054345_change_images_table_add_cascade.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class ChangeImagesTableAddCascade extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('images', function (Blueprint $table) {
+            //外部キーの削除！その後にまた外部制約の設定をすること
+            $table->dropForeign(['article_id']);
+            $table->foreign('article_id')->references('article_id')->on('articles')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('images', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/laravel-vue-app/resources/views/articles/create.blade.php
+++ b/laravel-vue-app/resources/views/articles/create.blade.php
@@ -36,7 +36,7 @@
 
     {{-- 画像登録 --}}
     <p>
-        <input type="file" class="btn image" name="image" value="画像登録" multiple/>
+        <input type="file" class="btn image" name="image" value="画像登録"/>
     </p>
 
     {{-- 一覧ページへの遷移ボタン --}}

--- a/laravel-vue-app/resources/views/articles/edit.blade.php
+++ b/laravel-vue-app/resources/views/articles/edit.blade.php
@@ -24,7 +24,7 @@
 
             {{-- 画像登録 --}}
             <p>
-              <input type="file" class="btn image" name="image" value="画像登録" multiple/>
+              <input type="file" class="btn image" name="image" value="画像登録"/>
             </p>
         </form>
 


### PR DESCRIPTION
What
・マイグレーションファイルの作成
・ArticleController@destroyの編集（途中）

Why
・画像を添付したノートが削除された際に画像も一緒にDBから削除するため（カスケード関係を結ぶ）
・ストレージからも画像が削除されるように現在編集中です（現状はストレージには画像が削除されず残ったまま）